### PR TITLE
don't allow compiler warnings on runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
             - name: "Install dependencies"
               run: sudo apt install -y libsdl2-dev
             - name: "cmake configure"
-              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL2
+              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL2 -DFAIL_ON_WARNING=ON
             - name: "cmake build"
               run: cmake --build build --config Release
 
@@ -27,7 +27,7 @@ jobs:
             - name: "Copy SDL2"
               run: Copy-Item -Path ".\SDL2-2.32.10\*" -Destination ".\libs\SDL2" -Recurse
             - name: "cmake configure"
-              run: cmake -S . -B build -G "Visual Studio 17 2022" -DACTIVE_PLATFORM=SDL2
+              run: cmake -S . -B build -G "Visual Studio 17 2022" -DACTIVE_PLATFORM=SDL2 -DFAIL_ON_WARNING=ON
             - name: "cmake build"
               run: cmake --build build --config Release
 
@@ -42,7 +42,7 @@ jobs:
             - name: "Copy SDL3"
               run: Copy-Item -Path ".\SDL3-3.2.24\*" -Destination ".\libs\SDL3" -Recurse
             - name: "cmake configure"
-              run: cmake -S . -B build -G "Visual Studio 17 2022" -DACTIVE_PLATFORM=SDL3
+              run: cmake -S . -B build -G "Visual Studio 17 2022" -DACTIVE_PLATFORM=SDL3 -DFAIL_ON_WARNING=ON
             - name: "cmake build"
               run: cmake --build build --config Release
 
@@ -55,7 +55,7 @@ jobs:
             - name: "Install SDL2"
               run: brew install sdl2
             - name: "cmake configure"
-              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL2
+              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL2 -DFAIL_ON_WARNING=ON
             - name: "cmake build"
               run: cmake --build build --config Release
 
@@ -68,6 +68,6 @@ jobs:
             - name: "Install SDL3"
               run: brew install sdl3
             - name: "cmake configure"
-              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL3
+              run: cmake -S . -B build -G "Ninja" -DACTIVE_PLATFORM=SDL3 -DFAIL_ON_WARNING=ON
             - name: "cmake build"
               run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.24)
 
 project(openmadoola LANGUAGES C CXX)
 
@@ -7,6 +7,8 @@ set(ACTIVE_PLATFORM SDL2 CACHE STRING "Default platform is SDL2")
 set_property(CACHE ACTIVE_PLATFORM PROPERTY STRINGS ${PLATFORM_LIST})
 
 option(SANITIZE "Compile with asan/ubsan (gcc/clang only)" OFF)
+
+option(FAIL_ON_WARNING "Fail the build if there's a compiler warning" OFF)
 
 add_executable(openmadoola WIN32)
 
@@ -255,6 +257,10 @@ else()
         target_compile_options(openmadoola PRIVATE -fsanitize=address,undefined)
         target_link_options(openmadoola PRIVATE -fsanitize=address,undefined)
     endif()
+endif()
+
+if(FAIL_ON_WARNING)
+    set_property(TARGET openmadoola PROPERTY COMPILE_WARNING_AS_ERROR ON)
 endif()
 
 # language versions

--- a/libs/nes_apu/Blip_Buffer.cpp
+++ b/libs/nes_apu/Blip_Buffer.cpp
@@ -353,7 +353,7 @@ void blip_eq_t::generate( float out [], int count ) const
 	
 	gen_sinc( out, count, oversample * cutoff_adj, treble, cutoff );
 	
-	kaiser_window( out, count, kaiser );
+	kaiser_window( out, count, static_cast<float>(kaiser) );
 }
 
 void Blip_Synth_::treble_eq( blip_eq_t const& eq )

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -189,10 +189,10 @@ void Graphics_DrawTile(int x, int y, int tilenum, int palnum, int mirror) {
 }
 
 // you need to change the below functions if any of these fail
-static_assert(TILE_WIDTH == 8);
-static_assert(TILE_HEIGHT == 8);
-static_assert(TILE_SIZE == 64);
-static_assert(PALETTE_SIZE == 4);
+static_assert(TILE_WIDTH == 8, "invalid tile width");
+static_assert(TILE_HEIGHT == 8, "invalid tile height");
+static_assert(TILE_SIZE == 64, "invalid tile size");
+static_assert(PALETTE_SIZE == 4, "invalid palette size");
 
 #if defined(OM_AMD64)
 // GCC/clang need to be told they're allowed to use AVX2, MSVC doesn't


### PR DESCRIPTION
makes it easier to tell when a change causes a new warning